### PR TITLE
feat: Added TypedArray Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These types are supported out of the box by SuperJSON.
 - Date
 - Set
 - Map
+- TypedArray (Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array)
 
 ### Planned Support
 
@@ -95,7 +96,6 @@ While not currently supported these types are planned to be supported in the nea
 - Symbols (#1)
 - Functions (#2)
 - Buffer (#3)
-- Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array (#4)
 - [Immutable.js][immutable] (#5)
 
 If you'd like to see other built-in types or data libraries supported, please open an [issue][feature-issue].

--- a/packages/@onedeadpixel/superjson/README.md
+++ b/packages/@onedeadpixel/superjson/README.md
@@ -78,6 +78,7 @@ These types are supported out of the box by SuperJSON.
 - Date
 - Set
 - Map
+- TypedArray (Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array)
 
 ## Custom Types
 

--- a/packages/@onedeadpixel/superjson/src/transformers/TypedArray.ts
+++ b/packages/@onedeadpixel/superjson/src/transformers/TypedArray.ts
@@ -1,0 +1,49 @@
+/**
+ * @module @onedeadpixel/superjson
+ */
+import { SuperJSON } from '../SuperJSON'
+
+/**
+ * Map of TypedArray constructors
+ */
+const typedArrayConstructors = new Map<string, any>([
+  ['Int8Array', Int8Array],
+  ['Uint8Array', Uint8Array],
+  ['Uint8ClampedArray', Uint8ClampedArray],
+  ['Int16Array', Int16Array],
+  ['Uint16Array', Uint16Array],
+  ['Int32Array', Int32Array],
+  ['Uint32Array', Uint32Array],
+  ['Float32Array', Float32Array],
+  ['Float64Array', Float64Array]
+])
+
+/**
+ * Registers the core JS TypedArrays
+ *
+ * Supports the following TypedArrays:
+ *
+ *  - Int8Array
+ *  - Uint8Array
+ *  - Uint8ClampedArray
+ *  - Int16Array
+ *  - Uint16Array
+ *  - Int32Array
+ *  - Uint32Array
+ *  - Float32Array
+ *  - Float64Array
+ *
+ * @param sjson SuperJSON instance to register TypedArrays to
+ */
+export function registerTypedArrays(sjson: SuperJSON) {
+  for (const [name, TypedArray] of typedArrayConstructors.entries()) {
+    /* istanbul ignore else */
+    if (TypedArray) {
+      sjson.register(TypedArray, {
+        name,
+        toJSONValue: (typedArray: any) => Array.from(typedArray.values()),
+        fromJSONValue: arrayOfValues => TypedArray.from(arrayOfValues)
+      })
+    }
+  }
+}

--- a/packages/@onedeadpixel/superjson/src/transformers/__tests__/TypedArray.test.ts
+++ b/packages/@onedeadpixel/superjson/src/transformers/__tests__/TypedArray.test.ts
@@ -1,0 +1,32 @@
+import { SuperJSON } from '../../SuperJSON'
+import { registerTypedArrays } from '../TypedArray'
+
+let sjson: SuperJSON
+
+beforeEach(() => {
+  sjson = new SuperJSON()
+})
+
+test.each`
+  name                   | value
+  ${'Int8Array'}         | ${Int8Array.from([1, 2, 3])}
+  ${'Uint8Array'}        | ${Uint8Array.from([1, 2, 3])}
+  ${'Uint8ClampedArray'} | ${Uint8ClampedArray.from([1, 2, 3])}
+  ${'Int16Array'}        | ${Int16Array.from([1, 2, 3])}
+  ${'Uint16Array'}       | ${Uint16Array.from([1, 2, 3])}
+  ${'Int32Array'}        | ${Int32Array.from([1, 2, 3])}
+  ${'Uint32Array'}       | ${Uint32Array.from([1, 2, 3])}
+  ${'Float32Array'}      | ${Float32Array.from([1, 2, 3])}
+  ${'Float64Array'}      | ${Float64Array.from([1, 2, 3])}
+`('registerTypedArrays adds support for $name', ({ value }) => {
+  registerTypedArrays(sjson)
+
+  const str = sjson.stringify(value)
+
+  expect(str).toMatchSnapshot()
+
+  const parsed = sjson.parse(str)
+
+  expect(parsed.constructor).toBe(value.constructor)
+  expect(Array.from(parsed.values())).toEqual(Array.from(value.values()))
+})

--- a/packages/@onedeadpixel/superjson/src/transformers/__tests__/__snapshots__/TypedArray.test.ts.snap
+++ b/packages/@onedeadpixel/superjson/src/transformers/__tests__/__snapshots__/TypedArray.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`registerTypedArrays adds support for Float32Array 1`] = `"{\\"__sj_type\\":\\"Float32Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Float64Array 1`] = `"{\\"__sj_type\\":\\"Float64Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Int8Array 1`] = `"{\\"__sj_type\\":\\"Int8Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Int16Array 1`] = `"{\\"__sj_type\\":\\"Int16Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Int32Array 1`] = `"{\\"__sj_type\\":\\"Int32Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Uint8Array 1`] = `"{\\"__sj_type\\":\\"Uint8Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Uint8ClampedArray 1`] = `"{\\"__sj_type\\":\\"Uint8ClampedArray\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Uint16Array 1`] = `"{\\"__sj_type\\":\\"Uint16Array\\",\\"__sj_value\\":[1,2,3]}"`;
+
+exports[`registerTypedArrays adds support for Uint32Array 1`] = `"{\\"__sj_type\\":\\"Uint32Array\\",\\"__sj_value\\":[1,2,3]}"`;

--- a/packages/@onedeadpixel/superjson/src/transformers/__tests__/index.test.ts
+++ b/packages/@onedeadpixel/superjson/src/transformers/__tests__/index.test.ts
@@ -3,10 +3,12 @@ import { SuperJSON } from '../../SuperJSON'
 import { registerDate } from '../Date'
 import { registerMap } from '../Map'
 import { registerSet } from '../Set'
+import { registerTypedArrays } from '../TypedArray'
 
 jest.mock('../Date')
 jest.mock('../Map')
 jest.mock('../Set')
+jest.mock('../TypedArray')
 
 let sjson: SuperJSON
 
@@ -20,4 +22,5 @@ test('registerAll should register all transformers', () => {
   expect(registerDate).toHaveBeenCalledWith(sjson)
   expect(registerMap).toHaveBeenCalledWith(sjson)
   expect(registerSet).toHaveBeenCalledWith(sjson)
+  expect(registerTypedArrays).toHaveBeenCalledWith(sjson)
 })

--- a/packages/@onedeadpixel/superjson/src/transformers/index.ts
+++ b/packages/@onedeadpixel/superjson/src/transformers/index.ts
@@ -5,10 +5,12 @@ import { SuperJSON } from '../SuperJSON'
 import { registerDate } from './Date'
 import { registerMap } from './Map'
 import { registerSet } from './Set'
+import { registerTypedArrays } from './TypedArray'
 
 export * from './Date'
 export * from './Map'
 export * from './Set'
+export * from './TypedArray'
 
 /**
  * Registers all the core JS classes
@@ -19,4 +21,5 @@ export function registerAll(sjson: SuperJSON) {
   registerDate(sjson)
   registerMap(sjson)
   registerSet(sjson)
+  registerTypedArrays(sjson)
 }


### PR DESCRIPTION
SuperJSON can now serialize TypedArrays.

- Int8Array
- Uint8Array
- Uint8ClampedArray
- Int16Array
- Uint16Array
- Int32Array
- Uint32Array
- Float32Array
- Float64Array

Resolves #4